### PR TITLE
Use explicit spaces in Spanish and French translations

### DIFF
--- a/src/changelog.sty
+++ b/src/changelog.sty
@@ -61,7 +61,7 @@
 \DeclareTranslation{German}{changelog-Unreleased}{Unver\"{o}ffentlicht}
 \DeclareTranslation{German}{changelog-Yanked}{Zur{\"u}ckgezogen}
 % Spanish translations by David Arnold <dar@xoe.solutions>
-\DeclareTranslation{Spanish}{changelog}{Registro de cambios}
+\DeclareTranslation{Spanish}{changelog}{Registro~de~cambios}
 \DeclareTranslation{Spanish}{changelog-Added}{Agregado}
 \DeclareTranslation{Spanish}{changelog-Changed}{Cambiado}
 \DeclareTranslation{Spanish}{changelog-Deprecated}{Obsoleto}
@@ -69,10 +69,10 @@
 \DeclareTranslation{Spanish}{changelog-Fixed}{Arreglado}
 \DeclareTranslation{Spanish}{changelog-Security}{Seguridad}
 \DeclareTranslation{Spanish}{changelog-Miscellaneous}{Miscel{\'a}neo}
-\DeclareTranslation{Spanish}{changelog-Unreleased}{No Publicado}
+\DeclareTranslation{Spanish}{changelog-Unreleased}{No~Publicado}
 \DeclareTranslation{Spanish}{changelog-Yanked}{REVOCADO}
 % French translations by Damien Calesse <github.com/kranack>
-\DeclareTranslation{French}{changelog}{Journal des modifications}
+\DeclareTranslation{French}{changelog}{Journal~des~modifications}
 \DeclareTranslation{French}{changelog-Added}{Ajouté}
 \DeclareTranslation{French}{changelog-Changed}{Modifié}
 \DeclareTranslation{French}{changelog-Deprecated}{Déprécié}
@@ -80,7 +80,7 @@
 \DeclareTranslation{French}{changelog-Fixed}{Corrigé}
 \DeclareTranslation{French}{changelog-Security}{Sécurité}
 \DeclareTranslation{French}{changelog-Miscellaneous}{Divers}
-\DeclareTranslation{French}{changelog-Unreleased}{Non publié}
+\DeclareTranslation{French}{changelog-Unreleased}{Non~publié}
 \DeclareTranslation{French}{changelog-Yanked}{Annulé}
 % Japanese translations by cmplstofB <github.com/cmplstofB>
 \DeclareTranslation{Japanese}{changelog}{変更履歴}


### PR DESCRIPTION
`expl3` requires that all spaces are made explicit as `~`. I didn't catch this when the translations were submitted.

Closes https://github.com/9999years/latex-changelog/issues/30